### PR TITLE
Loosen version requirement for JSON API client

### DIFF
--- a/productive.gemspec
+++ b/productive.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
 
   s.add_dependency 'rack'
-  s.add_dependency 'json_api_client', '1.5.2'
+  s.add_dependency 'json_api_client', '~> 1.21'
   s.add_dependency 'request_store', '~> 1.3'
 end


### PR DESCRIPTION
Closes #47 

We use the gem using this modification for a while now and everything works as expected. Therefore, I think it's safe to merge into upstream.