### PR TITLE
updated paginator

### DIFF
--- a/lib/productive/version.rb
+++ b/lib/productive/version.rb
@@ -1,3 +1,3 @@
 module Productive
-  VERSION = '0.6.58'.freeze
+  VERSION = '0.6.59'.freeze
 end

--- a/productive.gemspec
+++ b/productive.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
 
   s.add_dependency 'rack'
-  s.add_dependency 'json_api_client', '>= 1.5.2'
+  s.add_dependency 'json_api_client', '>= 1.5.3'
   s.add_dependency 'request_store', '~> 1.3'
 end


### PR DESCRIPTION
In `json_api_client` v 1.5.3, the `Paginator` class has been updated to have configurable `page` and `per_page` param names, which resulted with our custom paginator not working as it's missing the class methods.

This PR:
* updates `JsonApiPaginator` to include `page` and `per_page` configurable attributes
* updates some of it's methods to resemble the original paginator from `json_api_client`
* updates min dependency version to 1.5.3