### PR TITLE
Fix `has_one` syntax for widget

### DIFF
--- a/lib/productive/resources/widget.rb
+++ b/lib/productive/resources/widget.rb
@@ -1,5 +1,5 @@
 module Productive
   class Widget < BaseAccount
-    has_one: dashboard
+    has_one :dashboard
   end
 end


### PR DESCRIPTION
The current version 0.6.62 crashes when loading its code with the following message:

```
SyntaxError: /Users/andy/ruby/3.1.0/gems/productive-0.6.62/lib/productive/resources/widget.rb:3: syntax error, unexpected ':', expecting `end'
    has_one: dashboard
```

According to other resource classes, the syntax should be `has_one :dashboard`.