### PR TITLE
Add custom endpoints for deals

### DIFF
--- a/lib/productive/resources/deal.rb
+++ b/lib/productive/resources/deal.rb
@@ -2,5 +2,9 @@ module Productive
   class Deal < BaseAccount
     has_one :deal_status
     has_one :lost_reason
+
+    custom_endpoint :open, on: :member, request_method: :put
+    custom_endpoint :close, on: :member, request_method: :put
+    custom_endpoint :convert_to_budget, on: :member, request_method: :put
   end
 end


### PR DESCRIPTION
According to the developer documentation of Productive, deals have three custom methods, `open`, `close` and `convert_to_budget`.

To make use of those, they need to be mapped in the resource class. Afterward, it is possible to e.g. call `Productive::Deal.find(9873426948).first.close`.