### PR TITLE
[update] Add approval policy assignment association to person resource

### DIFF
--- a/lib/productive/resources/person.rb
+++ b/lib/productive/resources/person.rb
@@ -1,5 +1,7 @@
 module Productive
   class Person < BaseAccount
+    has_one :approval_policy_assignment
+
     def name
       "#{first_name} #{last_name}".strip
     end

--- a/lib/productive/version.rb
+++ b/lib/productive/version.rb
@@ -1,3 +1,3 @@
 module Productive
-  VERSION = '0.6.80'.freeze
+  VERSION = '0.6.81'.freeze
 end


### PR DESCRIPTION
PR info:
Added has_one ApprovalPolicyAssignment association to Person resource to resolve issues with devportal breaking when fetching people from 109 org.